### PR TITLE
Reshape and permute

### DIFF
--- a/TensorStack.m
+++ b/TensorStack.m
@@ -137,6 +137,7 @@ classdef TensorStack
       function [tfData] = my_subsref(oStack, S)
          % - Retrieving stack size information
          vnRefTensorSize = size(oStack);
+         nRefNumDims = numel(vnRefTensorSize);
 
          % - Cleaning input indices (colon or linear indices)
          coSubs = cleansubs(S.subs, vnRefTensorSize);
@@ -163,10 +164,14 @@ classdef TensorStack
          end
 
          % - Forbid wrapped-up dimensions for permuted dimensions
-         %TODO
+         vbPermutedDims = 1:numel(oStack.vnDimsOrder) ~= oStack.vnDimsOrder;
+         if (nNumDims < nRefNumDims) && any(vbPermutedDims(nNumDims:end))
+            error('TensorStack:badsubscript', ...
+                  '*** TensorStack: Only limited referencing styles are supported. Permuted dimensions cannot be linearly indexed.');
+         end
 
          % - Forbid wrapped-up dimensions before the concatenation dimension
-         if (nNumDims < numel(vnRefTensorSize)) && (nNumDims <= oStack.nStackDim)
+         if (nNumDims < nRefNumDims) && (nNumDims <= oStack.nStackDim)
             error('TensorStack:badsubscript', ...
                   '*** TensorStack: Only limited referencing styles are supported. The concatenated stack dimension [%d] must be referenced independently.', ...
                   oStack.nStackDim);

--- a/TensorStack.m
+++ b/TensorStack.m
@@ -183,8 +183,8 @@ classdef TensorStack
          end
 
          % - Forbid wrapped-up dimensions before the concatenation dimension
-         %TODO check for any of nStackDim split
-         if (nNumDims < nRefNumDims) && (nNumDims <= oStack.nStackDim)
+         nLastStackDim = find(oStack.vnSplitDims == oStack.nStackDim, 1, 'last');
+         if (nNumDims < nRefNumDims) && (nNumDims <= nLastStackDim)
             error('TensorStack:badsubscript', ...
                   '*** TensorStack: Only limited referencing styles are supported. The concatenated stack dimension [%d] must be referenced independently.', ...
                   oStack.nStackDim);

--- a/TensorStack.m
+++ b/TensorStack.m
@@ -133,7 +133,7 @@ classdef TensorStack
                '*** TensorStack: Assignment is not supported.');
       end
       
-      % other_subsref - Standard array referencing
+      % my_subsref - Standard array referencing
       function [tfData] = my_subsref(oStack, S)
          % - Retrieving stack size information
          vnRefTensorSize = size(oStack);
@@ -180,7 +180,7 @@ classdef TensorStack
          % - Check stack references
          if any(cellfun(@max, coSubs(~vbIsColon)) > vnWrappedTensorSize(~vbIsColon))
             error('TensorStack:badsubscript', ...
-                  'Index exceeds matrix dimensions.');
+                  '*** TensorStack: Index exceeds matrix dimensions.');
          end
 
          % - Permute data size and indices
@@ -447,8 +447,8 @@ function isvalidsubscript(oRefs)
       end
       
    catch
-      error('MappedTensor:badsubscript', ...
-            '*** MappedTensor: Subscript indices must either be real positive integers or logicals.');
+      error('TensorStack:badsubscript', ...
+            '*** TensorStack: Subscript indices must either be real positive integers or logicals.');
    end
 end
 

--- a/TensorStack.m
+++ b/TensorStack.m
@@ -165,7 +165,7 @@ classdef TensorStack
          % - Catch "all colon" entire stack referencing
          if all(vbIsColon)
             tfData = oStack.retrieve_all();
-            tfData = reshape(tfData, vnDataSize);
+            tfData = reshape(tfData, [vnDataSize, 1]);
             return
          end
 
@@ -223,7 +223,6 @@ classdef TensorStack
                   oStack.vnSplitSize(vbDimMask));
                cMergedSubs{ii} = reshape(vnDimIndices(cDimSubs{:}), [], 1);
             end
-            %TODO linear indexing case ?
          end
 
          % - Retrieve data from sub-tensors, reshape and permute it
@@ -313,6 +312,9 @@ classdef TensorStack
       function varargout = size(oStack, vnDimensions)
          % - Get tensor stack size and permute it
          vnSize = oStack.vnSplitSize(oStack.vnDimsOrder);
+
+         % - Remove trailing 1's
+         vnSize = vnSize(1:find(vnSize ~= 1, 1, 'last'));
 
          % - Return specific dimension(s)
          if (exist('vnDimensions', 'var'))
@@ -449,6 +451,9 @@ classdef TensorStack
                   '*** TensorStack: Size must be a vector of positive integers.');
          end
 
+         % - Remove trailing ones
+         vnNewSize = vnNewSize(1:find(vnNewSize ~= 1, 1, 'last'));
+
          % - Iteratively allocate old dimensions info to new dimensions
          nNumberNewDims = numel(vnNewSize);
          vnNewDimsOrder = zeros(1, nNumberNewDims);
@@ -482,8 +487,8 @@ classdef TensorStack
          % - Assign new permutation order to newly split dimensions
          for ii=2:nNumberNewDims
             if vnNewDimsOrder(ii) == vnNewDimsOrder(ii - 1)
-               vbOrders = vnNewDimsOrder > vnNewDimsOrder(ii);
-               vnNewDimsOrder(ii) = vnNewDimsOrder(ii) + 1;
+               vbOrders = vnNewDimsOrder >= vnNewDimsOrder(ii);
+               vbOrders(ii - 1) = false;
                vnNewDimsOrder(vbOrders) = vnNewDimsOrder(vbOrders) + 1;
             end
          end

--- a/TestTensorStack.m
+++ b/TestTensorStack.m
@@ -1,12 +1,14 @@
+% Test suite for TensorStack
+% Use 'run(TestTensorStack)' to run the whole suite.
 classdef TestTensorStack < matlab.unittest.TestCase
    
     properties
         stack       % tested TensorStack
-        real_stack  % Corresponding regular array
+        real_stack  % corresponding regular array
     end
     
     properties (TestParameter)
-        % test indexing
+        % tested indexing schemas
         subs = struct( ...
             'all', {{':', ':', ':'}}, ...
             'flat', {{':'}}, ...
@@ -21,14 +23,14 @@ classdef TestTensorStack < matlab.unittest.TestCase
             'part5', {{1:3, 3, 4:5}}, ...
             'part6', {{':', 3:end, 4:5}}, ...
             'part7', {{':', [3, 1, 2], ':'}});
-        % test permutations
+        % tested permutations
         order = struct( ...
             'unchanged', [1, 2, 3], ...
             'reverse', [3, 2, 1], ...
             'invert1', [2, 1, 3], ...
             'invert2', [1, 3, 2], ...
             'shuffle', [2, 3, 1]);
-        % test reshaping (split only)
+        % tested new size for reshaping (split only)
         newsize = struct( ...
             'unchanged', [3, 12, 5], ...
             'unknown1', {{3, [], 5}}, ...
@@ -44,10 +46,14 @@ classdef TestTensorStack < matlab.unittest.TestCase
             'split5', [3, 3, 2, 2, 5]);
         % seed for random permutations
         permseed = {1, 22, 542, 445, 55324};
+        % tested splits for 12
+        splits = { ...
+            [2, 6], [6, 2], [3, 4], [4, 3], [2, 2, 3], [3, 2, 2], [2, 3, 2]};
     end
 
     methods (TestMethodSetup)
         function createStack(testCase)
+            % tested data, as a concatenation of 3 arrays
             rng(1)
             data1 = randn(3, 4, 5);
             data2 = randn(3, 7, 5);
@@ -58,47 +64,83 @@ classdef TestTensorStack < matlab.unittest.TestCase
     end
 
     methods (Test)
+        % test indexing
         function testSubsref(testCase, subs)
             testCase.verifyEqual( ...
                 testCase.stack(subs{:}), testCase.real_stack(subs{:}));
         end
 
+        % test permutation
         function testPermute(testCase, order)
+            % permute stack
             pstack = permute(testCase.stack, order);
             preal = permute(testCase.real_stack, order);
             testCase.verifySize(pstack, size(preal));
-            testCase.verifyEqual(pstack(:, :, :), preal(:, :, :));
+            testCase.verifyEqual(pstack(:, :, :), preal);
+
+            % restore original order
+            ppstack = ipermute(pstack, order);
+            testCase.verifySize(ppstack, size(testCase.real_stack));
+            testCase.verifyEqual(ppstack(:, :, :), testCase.real_stack);
         end
         
+        % test reshaping
         function testReshape(testCase, newsize)
             if iscell(newsize)
-                pstack = reshape(testCase.stack, newsize{:});
-                preal = reshape(testCase.real_stack, newsize{:});
+                rstack = reshape(testCase.stack, newsize{:});
+                rreal = reshape(testCase.real_stack, newsize{:});
             else
-                pstack = reshape(testCase.stack, newsize);
-                preal = reshape(testCase.real_stack, newsize);
+                rstack = reshape(testCase.stack, newsize);
+                rreal = reshape(testCase.real_stack, newsize);
             end
-            testCase.verifySize(pstack, size(preal));
-            testCase.verifyEqual(pstack(:, :, :), preal(:, :, :));
+            colons = repmat({':'}, ndims(rreal), 1);
+            testCase.verifySize(rstack, size(rreal));
+            testCase.verifyEqual(rstack(colons{:}), rreal);
         end
 
+        % test reshaping + random permutation
         function testReshapePermute(testCase, newsize, permseed)
             if iscell(newsize)
-                pstack = reshape(testCase.stack, newsize{:});
-                preal = reshape(testCase.real_stack, newsize{:});
+                rstack = reshape(testCase.stack, newsize{:});
+                rreal = reshape(testCase.real_stack, newsize{:});
             else
-                pstack = reshape(testCase.stack, newsize);
-                preal = reshape(testCase.real_stack, newsize);
+                rstack = reshape(testCase.stack, newsize);
+                rreal = reshape(testCase.real_stack, newsize);
             end
 
+            % random permutation
             rng(permseed)
-            rorder = randperm(ndims(preal));
-            pstack = permute(pstack, rorder);
-            preal = permute(preal, rorder);
+            rorder = randperm(ndims(rreal));
+            pstack = permute(rstack, rorder);
+            preal = permute(rreal, rorder);
 
+            colons = repmat({':'}, ndims(preal), 1);
             testCase.verifySize(pstack, size(preal));
-            testCase.verifyEqual(pstack(:, :, :), preal(:, :, :));
-        end
+            testCase.verifyEqual(pstack(colons{:}), preal);
 
+            % restore shape before permutation
+            ppstack = ipermute(pstack, rorder);
+            colons = repmat({':'}, ndims(rreal), 1);
+            testCase.verifySize(ppstack, size(rreal));
+            testCase.verifyEqual(ppstack(colons{:}), rreal);
+        end
+        % test permutation + reshape
+        function testPermuteReshape(testCase, order, splits)
+            % permutation
+            pstack = permute(testCase.stack, order);
+            preal = permute(testCase.real_stack, order);
+
+            % split dimension who is equal to 12
+            psize = size(preal);
+            split_dim = find(psize == 12);
+            rsize = [psize(1:(split_dim-1)), splits, psize((split_dim+1:end))];
+
+            % reshape and test
+            rstack = reshape(pstack, rsize);
+            rreal = reshape(preal, rsize);
+            colons = repmat({':'}, ndims(rreal), 1);
+            testCase.verifySize(rstack, size(rreal));
+            testCase.verifyEqual(rstack(colons{:}), rreal);
+        end
     end
 end

--- a/TestTensorStack.m
+++ b/TestTensorStack.m
@@ -1,0 +1,104 @@
+classdef TestTensorStack < matlab.unittest.TestCase
+   
+    properties
+        stack       % tested TensorStack
+        real_stack  % Corresponding regular array
+    end
+    
+    properties (TestParameter)
+        % test indexing
+        subs = struct( ...
+            'all', {{':', ':', ':'}}, ...
+            'flat', {{':'}}, ...
+            'wrapped', {{':', ':'}}, ...
+            'zero', {{2:1, ':', ':'}}, ...
+            'zero2', {{':', 2:1, ':'}}, ...
+            'zero3', {{':', ':', 2:1}}, ...
+            'part', {{':', ':', 3}}, ...
+            'part2', {{3, ':', ':'}}, ...
+            'part3', {{1:3, ':', ':'}}, ...
+            'part4', {{1:3, ':', 4:5}}, ...
+            'part5', {{1:3, 3, 4:5}}, ...
+            'part6', {{':', 3:end, 4:5}}, ...
+            'part7', {{':', [3, 1, 2], ':'}});
+        % test permutations
+        order = struct( ...
+            'unchanged', [1, 2, 3], ...
+            'reverse', [3, 2, 1], ...
+            'invert1', [2, 1, 3], ...
+            'invert2', [1, 3, 2], ...
+            'shuffle', [2, 3, 1]);
+        % test reshaping (split only)
+        newsize = struct( ...
+            'unchanged', [3, 12, 5], ...
+            'unknown1', {{3, [], 5}}, ...
+            'unknown2', {{3, [], 6, 5}}, ...
+            'unknown3', {{[], 2, 6, 5}}, ...
+            'dummy1', [3, 12, 5, 1], ...
+            'dummy2', [3, 12, 1, 5], ...
+            'dummy3', [3, 1, 1, 1, 12 5], ...
+            'split1', [3, 2, 6, 5], ...
+            'split2', [3, 3, 4, 5], ...
+            'split3', [3, 4, 3, 5], ...
+            'split4', [3, 2, 2, 3, 5], ...
+            'split5', [3, 3, 2, 2, 5]);
+        % seed for random permutations
+        permseed = {1, 22, 542, 445, 55324};
+    end
+
+    methods (TestMethodSetup)
+        function createStack(testCase)
+            rng(1)
+            data1 = randn(3, 4, 5);
+            data2 = randn(3, 7, 5);
+            data3 = randn(3, 1, 5);
+            testCase.stack = TensorStack(2, data1, data2, data3);
+            testCase.real_stack = cat(2, data1, data2, data3);
+        end
+    end
+
+    methods (Test)
+        function testSubsref(testCase, subs)
+            testCase.verifyEqual( ...
+                testCase.stack(subs{:}), testCase.real_stack(subs{:}));
+        end
+
+        function testPermute(testCase, order)
+            pstack = permute(testCase.stack, order);
+            preal = permute(testCase.real_stack, order);
+            testCase.verifySize(pstack, size(preal));
+            testCase.verifyEqual(pstack(:, :, :), preal(:, :, :));
+        end
+        
+        function testReshape(testCase, newsize)
+            if iscell(newsize)
+                pstack = reshape(testCase.stack, newsize{:});
+                preal = reshape(testCase.real_stack, newsize{:});
+            else
+                pstack = reshape(testCase.stack, newsize);
+                preal = reshape(testCase.real_stack, newsize);
+            end
+            testCase.verifySize(pstack, size(preal));
+            testCase.verifyEqual(pstack(:, :, :), preal(:, :, :));
+        end
+
+        function testReshapePermute(testCase, newsize, permseed)
+            if iscell(newsize)
+                pstack = reshape(testCase.stack, newsize{:});
+                preal = reshape(testCase.real_stack, newsize{:});
+            else
+                pstack = reshape(testCase.stack, newsize);
+                preal = reshape(testCase.real_stack, newsize);
+            end
+
+            rng(permseed)
+            rorder = randperm(ndims(preal));
+            pstack = permute(pstack, rorder);
+            preal = permute(preal, rorder);
+
+            testCase.verifySize(pstack, size(preal));
+            testCase.verifyEqual(pstack(:, :, :), preal(:, :, :));
+        end
+
+    end
+end

--- a/TestTensorStack.m
+++ b/TestTensorStack.m
@@ -45,7 +45,7 @@ classdef TestTensorStack < matlab.unittest.TestCase
             'split4', [3, 2, 2, 3, 5], ...
             'split5', [3, 3, 2, 2, 5]);
         % seeds for random permutations
-        permseed = {1, 22, 542, 445, 55324, 356};
+        permseed = {1, 22, 542, 445, 5534, 356, 34, 123};
         % tested splits for concatenated dimension (== 12)
         splits = { ...
             [2, 6], [6, 2], [3, 4], [4, 3], [2, 2, 3], [3, 2, 2], [2, 3, 2]};
@@ -172,6 +172,27 @@ classdef TestTensorStack < matlab.unittest.TestCase
             psubs = splitsubs(rorder);
 
             testCase.verifyEqual(pstack(psubs{:}), preal(psubs{:}));
+        end
+
+        % test limited linear indexing
+        function testForbiddenLinear1(testCase)
+            % illegal linear indexing if concatenated dimension is used
+            testCase.verifyError(@() testCase.stack(:, 3), ...
+                                 'TensorStack:badsubscript');
+        end
+
+        % test limited linear indexing
+        function testForbiddenLinear2(testCase)
+            % permute dimensions to get illegal linear indexing
+            pstack = permute(testCase.stack, [2, 1, 3]);
+            testCase.verifyError(@() pstack(:, 3), 'TensorStack:badsubscript');
+        end
+
+        % test limited linear indexing
+        function testForbiddenLinear3(testCase)
+            % reshape stack to get another illegal linear indexing
+            rstack = reshape(testCase.stack, [1, 1, 1, 3, 12, 5]);
+            testCase.verifyError(@() rstack(:, :, :, 3), 'TensorStack:badsubscript');
         end
     end
 end


### PR DESCRIPTION
Add permutation, limited reshaping (only split of existing dimensions).

I added a test suite... which is not exhaustive. Please add more corner cases :-).
May be we should add some information about these new features in the documentation of TensorStack.
