### PR TITLE
Permute dummys

### DIFF
--- a/TensorStack.m
+++ b/TensorStack.m
@@ -223,7 +223,10 @@ classdef TensorStack
       function [oStack] = permute(oStack, vnNewOrder)
          % - Test permutation indices
          vnTestedOrder = sort(vnNewOrder(:));
-         nNumDims = numel(oStack.vnDimsOrder);
+
+         nMaxOldDims = numel(oStack.vnDimsOrder);
+         nMaxNewDims = max(vnNewOrder);
+         nNumDims = max(nMaxOldDims, nMaxNewDims);
 
          try
             validateattributes(vnTestedOrder, {'numeric'}, ...
@@ -231,6 +234,13 @@ classdef TensorStack
          catch
             error('TensorStack:permute:badIndex', ...
                   '*** TensorStack/permute: invalid permutation indices');
+         end
+
+         % - Add dummy dimensions if necessary
+         for ii=(nMaxOldDims+1):nNumDims
+             oStack.vnSplitSize(ii) = 1;
+             oStack.vnSplitDims(ii) = oStack.vnSplitDims(end);
+             oStack.vnDimsOrder(ii) = ii;
          end
 
          % - Change dimensions order

--- a/TensorStack.m
+++ b/TensorStack.m
@@ -444,6 +444,15 @@ classdef TensorStack
                   '*** TensorStack: Index exceeds matrix dimensions.');
          end
 
+         % - Deal with unshown trailing dimensions adding them back
+         vnAllSize = oStack.vnSplitSize(oStack.vnDimsOrder);
+         vnTrailingDims = find(vnAllSize == 1);
+         nTrailingDims = sum(vnTrailingDims > find(vnAllSize ~= 1, 1, 'last'));
+
+         nNumDims = nNumDims + nTrailingDims;
+         coSubs(end+1:end+nTrailingDims) = {':'};
+         vnDataSize(end+1:end+nTrailingDims) = 1;
+
          % - Permute data size and indices
          vnInvOrder(oStack.vnDimsOrder(1:nNumDims)) = 1:nNumDims;
          vnSortedSize = vnDataSize(vnInvOrder);

--- a/TestTensorStack.m
+++ b/TestTensorStack.m
@@ -29,7 +29,10 @@ classdef TestTensorStack < matlab.unittest.TestCase
             'reverse', [3, 2, 1], ...
             'invert1', [2, 1, 3], ...
             'invert2', [1, 3, 2], ...
-            'shuffle', [2, 3, 1]);
+            'shuffle', [2, 3, 1], ...
+            'moredims1', [4, 1, 2, 3], ...
+            'moredims2', [3, 4, 1, 2], ...
+            'moredims3', [4, 1, 5, 2, 3]);
         % tested new sizes for reshaping (split only)
         newsize = struct( ...
             'unchanged', [3, 12, 5], ...
@@ -83,12 +86,14 @@ classdef TestTensorStack < matlab.unittest.TestCase
             pstack = permute(testCase.stack, order);
             preal = permute(testCase.real_stack, order);
             testCase.verifySize(pstack, size(preal));
-            testCase.verifyEqual(pstack(:, :, :), preal);
+            colons = repmat({':'}, ndims(preal), 1);
+            testCase.verifyEqual(pstack(colons{:}), preal);
 
             % restore original order
             ppstack = ipermute(pstack, order);
             testCase.verifySize(ppstack, size(testCase.real_stack));
-            testCase.verifyEqual(ppstack(:, :, :), testCase.real_stack);
+            colons = repmat({':'}, ndims(testCase.real_stack), 1);
+            testCase.verifyEqual(ppstack(colons{:}), testCase.real_stack);
         end
         
         % test reshaping

--- a/TestTensorStack.m
+++ b/TestTensorStack.m
@@ -41,7 +41,7 @@ classdef TestTensorStack < matlab.unittest.TestCase
             'unknown3', {{[], 2, 6, 5}}, ...
             'dummy1', [3, 12, 5, 1], ...
             'dummy2', [3, 12, 1, 5], ...
-            'dummy3', [3, 1, 1, 1, 12 5], ...
+            'dummy3', [3, 1, 1, 1, 12, 5], ...
             'split1', [3, 2, 6, 5], ...
             'split2', [3, 3, 4, 5], ...
             'split3', [3, 4, 3, 5], ...
@@ -177,6 +177,17 @@ classdef TestTensorStack < matlab.unittest.TestCase
             psubs = splitsubs(rorder);
 
             testCase.verifyEqual(pstack(psubs{:}), preal(psubs{:}));
+        end
+
+        % test indexing with dummy dimension removed after permutation
+        function testRemovedDummySubsref(testCase, subs)
+            rstack = reshape(testCase.stack, [3, 12, 1, 5]);
+            rreal = reshape(testCase.real_stack, [3, 12, 1, 5]);
+
+            pstack = permute(rstack, [1, 2, 4, 3]);
+            preal = permute(rreal, [1, 2, 4, 3]);
+
+            testCase.verifyEqual(pstack(subs{:}), preal(subs{:}));
         end
 
         % test limited linear indexing


### PR DESCRIPTION
This should fix retrieval issues with dummy dimensions permuted at the end.
